### PR TITLE
boot: bootutil: avoid full erase on BOOT_MAGIC_BAD in boot_set_next

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -573,10 +573,7 @@ boot_set_next(const struct flash_area *fa, bool active, bool confirm)
         if (active) {
             rc = BOOT_EBADVECT;
         } else {
-            /* The image slot is corrupt.  There is no way to recover, so erase the
-             * slot to allow future upgrades.
-             */
-            flash_area_erase(fa, 0, flash_area_get_size(fa));
+            /* This image will not be boot next time anyway */
             rc = BOOT_EBADIMAGE;
         }
         break;


### PR DESCRIPTION
Previously, boot_set_next() would perform a full slot erase when BOOT_MAGIC_BAD was detected. This is unnecessary, as boot_validate_slot() will later handle the invalid image appropriately by invoking boot_scramble_slot().